### PR TITLE
Replace objectionable terminolgy (whitelist/blacklist)

### DIFF
--- a/src/cbevent/conanfile.py
+++ b/src/cbevent/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 
 class cbeventConan(ConanFile):
     name = "cbevent"
-    version = "0.5"
+    version = "0.6"
     license = "BSD-2-Clause"
     url = "https://gitlab.bit9.local/dheater/cbevent"
     description = "CB Event structure shared between CBR linux event generators and the daemon"

--- a/src/cbevent/src/CB_EVENT_BLOCK_RESPONSE.h
+++ b/src/cbevent/src/CB_EVENT_BLOCK_RESPONSE.h
@@ -28,11 +28,9 @@ enum ProcessBlockType {
 ///   These enums help inform the server as to why
 enum TerminateFailureReason {
 	TerminateFailureReasonNone = 0, ///< Process was successfully terminated
-	ProcessWhiteListed, ///< We determined that the process was whitelisted
-			    ///< (failure details will have the WhiteListReason)
-	ProcessOpenFailure, ///< We failed to open a handle to the process
-			    ///< (failure details will contain NT_STATUS error
-			    ///< code)
+	ProcessOpenFailure = 2, ///< We failed to open a handle to the process
+				///< (failure details will contain NT_STATUS
+				///< error code)
 	ProcessTerminateFailure, ///< ZwTerminateProcess failed (failure details
 				 ///< will contain NT_STATUS error code)
 };

--- a/src/kmod/cb-isolation.c
+++ b/src/kmod/cb-isolation.c
@@ -162,7 +162,7 @@ void CbIsolationInterceptByAddrProtoPort(
 		return;
 	}
 
-	// Our whitelist of addresses is IPv4, so just block IPv6 addresses
+	// Our allowed list of addresses is IPv4, so just block IPv6 addresses
 	// acquire shared resource
 	if (isIpV4) {
 		int i;

--- a/src/kmod/drvmain.c
+++ b/src/kmod/drvmain.c
@@ -49,11 +49,11 @@ static int __init cbsensor_init(void)
 #define CB_RESOLV_FUNCTION(F_TYPE, F_NAME, ARGS_DECL) \
 	CB_RESOLV_VARIABLE(F_TYPE, F_NAME)
 
-	struct symbols_s symbols[] = { CB_RESOLV_SYMBOLS{ NULL, 0, NULL } };
-	struct symbol_list sym_list = {
-		.symbols = symbols,
-		.size = ARRAY_SIZE(symbols) - 1, // Prevent extra iterations
-		.count = 0,
+	struct symbols_s   symbols[] = { CB_RESOLV_SYMBOLS{ NULL, 0, NULL } };
+	struct symbol_list sym_list  = {
+		 .symbols = symbols,
+		 .size	  = ARRAY_SIZE(symbols) - 1, // Prevent extra iterations
+		 .count	  = 0,
 	};
 
 	PRINT_VERSION_INFO;

--- a/src/kmod/lsmutils.c
+++ b/src/kmod/lsmutils.c
@@ -28,33 +28,28 @@
 
 // Callback fn for kallsyms_on_each_symbol
 static int allsyms_find_symbol(void *data, const char *symstr,
-							   struct module *module, unsigned long address)
+			       struct module *module, unsigned long address)
 {
 	struct symbol_list *list = (struct symbol_list *)data;
-	struct symbols_s *curr_symbol;
+	struct symbols_s *  curr_symbol;
 
-	if (!list)
-	{
+	if (!list) {
 		return 0;
 	}
 
 	// Exit callback function sooner
-	if (list->count >= list->size)
-	{
+	if (list->count >= list->size) {
 		return 0;
 	}
 
-	for (curr_symbol = list->symbols;
-		 curr_symbol && curr_symbol->name; ++curr_symbol)
-	{
+	for (curr_symbol = list->symbols; curr_symbol && curr_symbol->name;
+	     ++curr_symbol) {
 		// Skip if found
-		if (*curr_symbol->addr)
-		{
+		if (*curr_symbol->addr) {
 			continue;
 		}
 
-		if (strcmp(symstr, curr_symbol->name) == 0)
-		{
+		if (strcmp(symstr, curr_symbol->name) == 0) {
 			list->count += 1;
 			*curr_symbol->addr = address;
 			break;
@@ -66,10 +61,9 @@ static int allsyms_find_symbol(void *data, const char *symstr,
 //
 // Primarily used to find private symbols
 //
-void lookup_symbols(struct symbol_list* sym_list)
+void lookup_symbols(struct symbol_list *sym_list)
 {
-	if (sym_list)
-	{
+	if (sym_list) {
 		// Clear out global struct containing static mappings of
 		// symbols to resolved addresses.
 		memset(&g_resolvedSymbols, 0, sizeof(g_resolvedSymbols));

--- a/src/kmod/priv.h
+++ b/src/kmod/priv.h
@@ -386,11 +386,11 @@ struct symbols_s {
 	unsigned long *addr;
 };
 struct symbol_list {
-    struct symbols_s *symbols;
-    unsigned long size;
-    unsigned long count;
+	struct symbols_s *symbols;
+	unsigned long	  size;
+	unsigned long	  count;
 };
-extern void lookup_symbols(struct symbol_list* sym_list);
+extern void lookup_symbols(struct symbol_list *sym_list);
 extern void printAddress(char *msg, const char *fn, const struct sock *sk,
 			 const struct sockaddr *localAddr,
 			 const struct sockaddr *remoteAddr);


### PR DESCRIPTION
Replace instances of `blacklist` with `denylist`. `whitelist` occurred once in and `enum` in the `cbevent` struct, but it is not used, so simply deleted it.

Signed-off-by: Daniel L. Heater <dheater@vmware.com>