### PR TITLE
Inline CANCEL_VOID macro

### DIFF
--- a/src/kmod/cb-test.h
+++ b/src/kmod/cb-test.h
@@ -80,10 +80,3 @@
 			return xcode; \
 		}                     \
 	} while (0)
-
-#define CANCEL_VOID(x)          \
-	do {                    \
-		if (!(x)) {     \
-			return; \
-		}               \
-	} while (0)

--- a/src/kmod/net-hooks.c
+++ b/src/kmod/net-hooks.c
@@ -619,7 +619,7 @@ static bool cb_getudppeername(struct sock *sk, union CB_SOCK_ADDR *remoteAddr,
 static void cb_getpeername(struct sock *sk, union CB_SOCK_ADDR *remoteAddr,
 			   struct msghdr *msg)
 {
-	if(!sk || !remoteAddr || !msg) {
+	if (!sk || !remoteAddr || !msg) {
 		return;
 	}
 
@@ -651,7 +651,7 @@ static void cb_getsockname(struct sock *sk, union CB_SOCK_ADDR *localAddr,
 {
 	struct inet_sock *inet;
 
-	if(!sk || !localAddr || !msg) {
+	if (!sk || !localAddr || !msg) {
 		return;
 	}
 

--- a/src/kmod/net-hooks.c
+++ b/src/kmod/net-hooks.c
@@ -619,9 +619,9 @@ static bool cb_getudppeername(struct sock *sk, union CB_SOCK_ADDR *remoteAddr,
 static void cb_getpeername(struct sock *sk, union CB_SOCK_ADDR *remoteAddr,
 			   struct msghdr *msg)
 {
-	CANCEL_VOID(sk);
-	CANCEL_VOID(remoteAddr);
-	CANCEL_VOID(msg);
+	if(!sk || !remoteAddr || !msg) {
+		return;
+	}
 
 	// Use msg->msg_name if we are doing UDP else ...
 	if (!cb_getudppeername(sk, remoteAddr, msg)) {
@@ -651,9 +651,9 @@ static void cb_getsockname(struct sock *sk, union CB_SOCK_ADDR *localAddr,
 {
 	struct inet_sock *inet;
 
-	CANCEL_VOID(sk);
-	CANCEL_VOID(localAddr);
-	CANCEL_VOID(msg);
+	if(!sk || !localAddr || !msg) {
+		return;
+	}
 
 	inet = inet_sk(sk);
 


### PR DESCRIPTION
Inline the `CANCEL_VOID` macro. Arguably the macro obfuscates the code by affecting the functions control flow (returning) in an opaque way.

From the Linux Coding Style

> Things to avoid when using macros:
>
>  macros that affect control flow:
> 
>     #define FOO(x)                                  \
>             do {                                    \
>                     if (blah(x) < 0)                \
>                             return -EBUGGERED;      \
>             } while (0)
> 
> is a very bad idea. It looks like a function call but exits the calling function; don’t break the internal parsers of those who will read the code.

https://www.kernel.org/doc/html/v4.10/process/coding-style.html#macros-enums-and-rtl