### PR TITLE
Inline CANCEL_MSG macro

### DIFF
--- a/src/kmod/cb-test.h
+++ b/src/kmod/cb-test.h
@@ -73,14 +73,6 @@
 		}                          \
 	} while (0)
 
-#define CANCEL_MSG(x, msg...)         \
-	do {                          \
-		if (!(x)) {           \
-			PRINTK(msg);  \
-			return xcode; \
-		}                     \
-	} while (0)
-
 #define CANCEL_VOID(x)          \
 	do {                    \
 		if (!(x)) {     \

--- a/src/kmod/file-helper.c
+++ b/src/kmod/file-helper.c
@@ -17,7 +17,7 @@ bool file_helper_init(void)
 char *dentry_to_path(struct dentry *dentry, char *buf)
 {
 	if (CB_RESOLVED(dentry_path) == NULL) {
-		PRINTK(KERN_ERR, "dentry_path is NULL.");
+		PRINTK(KERN_ERR, "Function pointer dentry_path is NULL.");
 		return NULL;
 	}
 	return CB_RESOLVED(dentry_path)(dentry, buf, PATH_MAX);

--- a/src/kmod/file-helper.c
+++ b/src/kmod/file-helper.c
@@ -16,8 +16,10 @@ bool file_helper_init(void)
 
 char *dentry_to_path(struct dentry *dentry, char *buf)
 {
-	char *xcode = NULL;
-	CANCEL_CB_RESOLVED(dentry_path);
+	if (CB_RESOLVED(dentry_path) == NULL) {
+		PRINTK(KERN_ERR, "dentry_path is NULL.");
+		return NULL;
+	}
 	return CB_RESOLVED(dentry_path)(dentry, buf, PATH_MAX);
 }
 

--- a/src/kmod/priv.h
+++ b/src/kmod/priv.h
@@ -332,9 +332,6 @@ extern int	     isSpecialFile(char *pathname, int len);
 #define TRY_CB_RESOLVED(S_NAME)                      \
 	TRY_MSG(CB_CHECK_RESOLVED(S_NAME), KERN_ERR, \
 		"Function pointer \"%s\" is NULL.", #S_NAME)
-#define CANCEL_CB_RESOLVED(S_NAME)                      \
-	CANCEL_MSG(CB_CHECK_RESOLVED(S_NAME), KERN_ERR, \
-		   "Function pointer \"%s\" is NULL.", #S_NAME)
 
 // Define a list of symbols using the CB_RESOLV_VARIABLE(V_TYPE, V_NAME) and
 // CB_RESOLV_FUNCTION(F_TYPE, F_NAME, ARGS_DECL) macros.

--- a/src/kmod/process-hooks.c
+++ b/src/kmod/process-hooks.c
@@ -21,7 +21,6 @@ static bool _get_cmdline(struct task_struct *task, unsigned long start_addr,
 			 unsigned long end_addr, int args, char *cmdLine,
 			 size_t cmdLineSize)
 {
-	bool	     xcode	= false;
 	unsigned int cmdLinePos = 0;
 	int	     i;
 	size_t	     len = 0;
@@ -29,7 +28,10 @@ static bool _get_cmdline(struct task_struct *task, unsigned long start_addr,
 	if (!task) {
 		return false;
 	}
-	CANCEL_CB_RESOLVED(access_process_vm);
+	if (CB_RESOLVED(access_process_vm) == NULL) {
+		PRINTK(KERN_ERR, "Function pointer access_process_vm is NULL.");
+		return false;
+	}
 
 	// Verify the buffer exists
 	if (cmdLine == NULL) {


### PR DESCRIPTION
Inline the `CANCEL_MSG` macro. Arguably the macro obfuscates the code by affecting the functions control flow (returning) in an opaque way.

> 
> From the Linux Coding Style
> 
>     Things to avoid when using macros:
> 
>     macros that affect control flow:
> 
>     #define FOO(x)                                  \
>             do {                                    \
>                     if (blah(x) < 0)                \
>                             return -EBUGGERED;      \
>             } while (0)
> 
>     is a very bad idea. It looks like a function call but exits the calling function; don’t break the internal parsers of those who will read the code.

https://www.kernel.org/doc/html/v4.10/process/coding-style.html#macros-enums-and-rtl