### PR TITLE
Generic Hashtable Improvements

### DIFF
--- a/src/kmod/hash-table-generic.h
+++ b/src/kmod/hash-table-generic.h
@@ -24,30 +24,30 @@
 
 struct HashTbl {
 	struct hashtbl_bkt *tablePtr;
-	struct list_head   genTables;
-	uint64_t	   numberOfBuckets;
-	uint32_t	   secret;
-	atomic64_t	   tableInstance;
-	atomic64_t	   tableAllocs;
-	atomic64_t	   tableShutdown; // shutting down = 1 running = 0
-	int		   key_len;
-	struct kmem_cache *hash_cache;
-	uint8_t		   name[20];
-	int		   key_offset;
-	int		   node_offset;
-	int cmp_len;
+	struct list_head    genTables;
+	uint64_t	    numberOfBuckets;
+	uint32_t	    secret;
+	atomic64_t	    tableInstance;
+	atomic64_t	    tableAllocs;
+	atomic64_t	    tableShutdown; // shutting down = 1 running = 0
+	int		    key_len;
+	struct kmem_cache * hash_cache;
+	uint8_t		    name[20];
+	int		    key_offset;
+	int		    node_offset;
+	int		    cmp_len;
 	bool (*cmp_key)(const void *a, const void *b, int len);
 	size_t base_size;
 };
 
 struct hashtbl_bkt {
-	spinlock_t lock;
+	spinlock_t	  lock;
 	struct hlist_head head;
 };
 
 struct HashTableNode {
 	struct hlist_node link;
-	uint32_t hash;
+	uint32_t	  hash;
 };
 
 extern uint64_t		g_hashtbl_generic_lock;
@@ -77,7 +77,7 @@ void		hash_table_test(void);
 
 // Use these when you want to more safely
 // access entry data.
-bool		hashtbl_getlocked_bucket(struct HashTbl *hashTblp, void *key, void **datap,
-					 struct hashtbl_bkt **bkt, unsigned long *flags);
-void		hashtbl_unlock_bucket(struct hashtbl_bkt *bkt, unsigned long flags);
-int		hashtbl_add_safe_generic(struct HashTbl *hashTblp, void *datap);
+bool hashtbl_getlocked_bucket(struct HashTbl *hashTblp, void *key, void **datap,
+			      struct hashtbl_bkt **bkt, unsigned long *flags);
+void hashtbl_unlock_bucket(struct hashtbl_bkt *bkt, unsigned long flags);
+int  hashtbl_add_safe_generic(struct HashTbl *hashTblp, void *datap);


### PR DESCRIPTION
Closes #10 

This includes per-bucket spinlocks. Each node entry in a bucket hash the full hash for faster lookups. The key comparison is optmized when 32bit aligned. A bunch of commmon hashtable lookup operations has been turned into helper functions. This also provides an interface for preventing duplicate entries on insert but you have to request to do it that way. This also provides a low level interface to allow the user of the generic hashtable to get safe copies or perform other safe operations as they see fit. The network hashtable should not be using this data structure and utilize an LRU cache oriented hashtable. Overall this provides scalability, performance and options to do things safer in the future.

