### PR TITLE
Fixup Clone Hook

### DIFF
--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -54,7 +54,9 @@ cbsensor-objs := drvmain.o \
                  file-types.o \
                  cb-procfs.o \
                  module-hooks.o \
-                 test-logging.o
+                 test-logging.o \
+                 ktfutce.o \
+
 CC=${CMAKE_C_COMPILER}")
 
 add_custom_command(OUTPUT ${DRIVER_FILE}
@@ -85,6 +87,7 @@ add_custom_command(OUTPUT ${DRIVER_FILE}
             syscall_stubs.S
             task-helper.c
             test-logging.c
+            ktfutce.c
         VERBATIM)
 
 add_custom_target(cbsensor ALL DEPENDS ${DRIVER_FILE})

--- a/src/kmod/drvmain.c
+++ b/src/kmod/drvmain.c
@@ -5,6 +5,7 @@
 
 #include "cb-isolation.h"
 #include "file-process-tracking.h"
+#include "ktfutce.h"
 #include "network-tracking.h"
 #include "priv.h"
 #include "process-tracking.h"
@@ -83,6 +84,7 @@ static int __init cbsensor_init(void)
 	TRY_STEP(BAN, !CbInitializeNetworkIsolation());
 	TRY_STEP(NET_IS, file_helper_init());
 	TRY_STEP(NET_IS, logger_initialize());
+	ktfutce_register();
 	TRY_STEP(TASK, netfilter_initialize(g_enableHooks));
 	TRY_STEP(NET_FIL, file_process_tracking_init());
 	TRY_STEP(FILE_PROC, lsm_initialize(g_enableHooks));
@@ -104,6 +106,7 @@ CATCH_FILE_PROC:
 CATCH_NET_FIL:
 	netfilter_cleanup(g_enableHooks);
 CATCH_TASK:
+	ktfutce_shutdown();
 	logger_shutdown();
 CATCH_NET_IS:
 	CbDestroyNetworkIsolation();
@@ -133,6 +136,7 @@ void cbsensor_shutdown(void)
 	syscall_shutdown(g_enableHooks);
 	lsm_shutdown();
 	netfilter_cleanup(g_enableHooks);
+	ktfutce_shutdown();
 }
 
 static void __exit cbsensor_cleanup(void)

--- a/src/kmod/ktfutce.c
+++ b/src/kmod/ktfutce.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018-2020 VMware, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "priv.h"
+#include "process-tracking.h"
+#include <linux/kthread.h>
+#include <linux/wait.h>
+
+//
+// ktfutce handles a queue of Fork events and the tgid in question.
+// We may want to pre-allocate a process tracking table entry and
+// send to here as well and fill in all the data.
+//
+// With our current fork hook we cannot safely lookup the new
+// task yet. So we throw the job into our kthread via a
+// wait queue. By the time this thread wakes the new task
+// will highly likely be available.
+//
+
+static DECLARE_WAIT_QUEUE_HEAD(clone_wait);
+struct clone_struct {
+	struct task_struct *task;
+	struct list_head    head;
+	spinlock_t	    lock;
+	unsigned long	    len;
+};
+static struct clone_struct clone_queue = { .task = NULL };
+
+struct clone_event {
+	struct list_head list;
+	pid_t		 pid;
+	struct CB_EVENT *event;
+};
+
+static int ktfutce_thread(void *arg);
+
+int ktfutce_register(void)
+{
+	int ret = 0;
+
+	memset(&clone_queue, 0, sizeof(clone_queue));
+	INIT_LIST_HEAD(&clone_queue.head);
+	spin_lock_init(&clone_queue.lock);
+
+	clone_queue.task = kthread_run(ktfutce_thread, NULL, "cb_ktfutce");
+	if (IS_ERR(clone_queue.task)) {
+		ret		 = PTR_ERR(clone_queue.task);
+		clone_queue.task = NULL;
+		return ret;
+	}
+	return ret;
+}
+
+// Probably should be called before logger shutdown
+void ktfutce_shutdown(void)
+{
+	if (clone_queue.task) {
+		struct task_struct *task = clone_queue.task;
+		clone_queue.task	 = NULL;
+		wake_up_interruptible(&clone_wait);
+		kthread_stop(task);
+	}
+}
+
+// Enqueue a fork event and ask the kthread to work on it
+int ktfutce_add_pid(pid_t pid, struct CB_EVENT *event, gfp_t mode)
+{
+	struct clone_event *clone_event = NULL;
+
+	if (!clone_queue.task) {
+		return -EINVAL;
+	}
+
+	// Can't be zero!
+	if (!pid) {
+		return -EINVAL;
+	}
+
+	clone_event = kzalloc(sizeof(*clone_event), mode);
+	if (!clone_event) {
+		return -ENOMEM;
+	}
+
+	INIT_LIST_HEAD(&clone_event->list);
+	clone_event->pid   = pid;
+	clone_event->event = event;
+
+	spin_lock(&clone_queue.lock);
+	list_add_tail(&clone_event->list, &clone_queue.head);
+	clone_queue.len += 1;
+	spin_unlock(&clone_queue.lock);
+	wake_up_interruptible(&clone_wait);
+
+	return 0;
+}
+
+static inline struct clone_event *clone_shift(void)
+{
+	struct clone_event *clone_event = NULL;
+
+	spin_lock(&clone_queue.lock);
+	if (list_empty(&clone_queue.head)) {
+		spin_unlock(&clone_queue.lock);
+		return NULL;
+	}
+
+	clone_event =
+		list_first_entry(&clone_queue.head, struct clone_event, list);
+	if (clone_event) {
+		clone_queue.len -= 1;
+		list_del_init(&clone_event->list);
+	}
+	spin_unlock(&clone_queue.lock);
+
+	return clone_event;
+}
+
+static int ktfutce_thread(void *arg)
+{
+	while (!kthread_should_stop()) {
+		pid_t		    pid;
+		struct task_struct *task	= NULL;
+		struct clone_event *clone_event = NULL;
+		struct CB_EVENT *   event	= NULL;
+
+		clone_event = clone_shift();
+		if (!clone_event) {
+			goto wait;
+		}
+
+		pid   = clone_event->pid;
+		event = clone_event->event;
+		kfree(clone_event);
+		clone_event = NULL;
+
+		task = cb_find_task(pid);
+
+		// We may not want these to do irq spinlocks
+		if (task && !(task->flags & PF_KTHREAD) && pid_alive(task) &&
+		    pid == task->tgid) {
+			// Depending on how safe it is to fill in the event
+			// data we may want to do this work here.
+			// This would mean less table lookups.
+			if (event) {
+				logger_submit_event(event);
+			}
+		} else {
+			process_tracking_remove_process(pid);
+			if (event) {
+				logger_free_event_on_error(event);
+			}
+		}
+	wait:
+		wait_event_interruptible_timeout(clone_wait,
+						 (clone_queue.task == NULL ||
+						  clone_queue.len > 0),
+						 msecs_to_jiffies(500));
+	}
+
+	return 0;
+}

--- a/src/kmod/ktfutce.c
+++ b/src/kmod/ktfutce.c
@@ -69,12 +69,7 @@ int ktfutce_add_pid(pid_t pid, struct CB_EVENT *event, gfp_t mode)
 {
 	struct clone_event *clone_event = NULL;
 
-	if (!clone_queue.task) {
-		return -EINVAL;
-	}
-
-	// Can't be zero!
-	if (!pid) {
+	if (!clone_queue.task || !pid) {
 		return -EINVAL;
 	}
 

--- a/src/kmod/ktfutce.c
+++ b/src/kmod/ktfutce.c
@@ -66,7 +66,7 @@ void ktfutce_shutdown(void)
 // Enqueue a fork event and ask the kthread to work on it
 int ktfutce_add_pid(pid_t pid, struct CB_EVENT *event, gfp_t mode)
 {
-	unsigned long flags;
+	unsigned long	    flags;
 	struct clone_event *clone_event = NULL;
 
 	if (!clone_queue.task || !pid) {
@@ -93,7 +93,7 @@ int ktfutce_add_pid(pid_t pid, struct CB_EVENT *event, gfp_t mode)
 
 static inline struct clone_event *clone_shift(void)
 {
-	unsigned long flags;
+	unsigned long	    flags;
 	struct clone_event *clone_event = NULL;
 
 	spin_lock_irqsave(&clone_queue.lock, flags);

--- a/src/kmod/ktfutce.c
+++ b/src/kmod/ktfutce.c
@@ -48,7 +48,6 @@ int ktfutce_register(void)
 	if (IS_ERR(clone_queue.task)) {
 		ret		 = PTR_ERR(clone_queue.task);
 		clone_queue.task = NULL;
-		return ret;
 	}
 	return ret;
 }

--- a/src/kmod/ktfutce.h
+++ b/src/kmod/ktfutce.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016-2020 VMware, Inc.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+//
+// ktfutce handles a queue of Fork events and the tgid in question.
+// We may want to pre-allocate a process tracking table entry and
+// send to here as well and fill in all the data.
+//
+// With our current fork hook we cannot safely lookup the new
+// task yet. So we throw the job into our kthread via a
+// wait queue. By the time this thread wakes the new task
+// will highly likely be available.
+//
+int  ktfutce_register(void);
+void ktfutce_shutdown(void);
+
+int ktfutce_add_pid(pid_t pid, struct CB_EVENT *event, gfp_t mode);


### PR DESCRIPTION
Closes #11 

Creates a kthread to better determine when a task clone event is a new tgid. This means preventing false fork events that happened on clone. This technically may not always work but should for the standard task scheduler. Also provides a path to get the start_time attribute more accurately without drastic means.

The clone hook was fairly dangerous in that we would use GFP_KERNEL allocations within that hook. That probably caused a lot of weird issues on RHEL6 for parent processes and waiting. 