### PR TITLE
Cleaned up pid list with trusted pids when process exits.

### DIFF
--- a/src/kmod/cb-banning.c
+++ b/src/kmod/cb-banning.c
@@ -319,6 +319,17 @@ void cbSetIgnoredProcess(pid_t pid)
 	}
 }
 
+void cbClearIgnoredProcess(pid_t pid)
+{
+    int64_t max = atomic64_read((atomic64_t *)&g_cb_ignored_pid_count);
+
+    if (max) {
+            atomic64_set((atomic64_t *)&g_cb_ignored_pid_count, 0);
+            memset(&g_cb_ignored_pids[0], 0, sizeof(pid_t) * CB_SENSOR_MAX_PIDS);
+            PRINTK(KERN_INFO, "Reset ignored list of pid=%u", pid);
+    }
+}
+
 bool cbIngoreUid(pid_t uid)
 {
 	int64_t i;

--- a/src/kmod/cb-banning.c
+++ b/src/kmod/cb-banning.c
@@ -325,9 +325,8 @@ void cbClearIgnoredProcess(pid_t pid)
 
 	if (max) {
 		atomic64_set((atomic64_t *)&g_cb_ignored_pid_count, 0);
-		memset(&g_cb_ignored_pids[0], 0,
+		memset(g_cb_ignored_pids, 0,
 		       sizeof(pid_t) * CB_SENSOR_MAX_PIDS);
-		PRINTK(KERN_INFO, "Reset ignored list of pid=%u", pid);
 	}
 }
 

--- a/src/kmod/cb-banning.c
+++ b/src/kmod/cb-banning.c
@@ -326,7 +326,7 @@ void cbClearIgnoredProcess(pid_t pid)
 	if (max) {
 		atomic64_set((atomic64_t *)&g_cb_ignored_pid_count, 0);
 		memset(g_cb_ignored_pids, 0,
-		       sizeof(pid_t) * CB_SENSOR_MAX_PIDS);
+		       sizeof(g_cb_ignored_pids));
 	}
 }
 

--- a/src/kmod/cb-banning.c
+++ b/src/kmod/cb-banning.c
@@ -321,13 +321,14 @@ void cbSetIgnoredProcess(pid_t pid)
 
 void cbClearIgnoredProcess(pid_t pid)
 {
-    int64_t max = atomic64_read((atomic64_t *)&g_cb_ignored_pid_count);
+	int64_t max = atomic64_read((atomic64_t *)&g_cb_ignored_pid_count);
 
-    if (max) {
-            atomic64_set((atomic64_t *)&g_cb_ignored_pid_count, 0);
-            memset(&g_cb_ignored_pids[0], 0, sizeof(pid_t) * CB_SENSOR_MAX_PIDS);
-            PRINTK(KERN_INFO, "Reset ignored list of pid=%u", pid);
-    }
+	if (max) {
+		atomic64_set((atomic64_t *)&g_cb_ignored_pid_count, 0);
+		memset(&g_cb_ignored_pids[0], 0,
+		       sizeof(pid_t) * CB_SENSOR_MAX_PIDS);
+		PRINTK(KERN_INFO, "Reset ignored list of pid=%u", pid);
+	}
 }
 
 bool cbIngoreUid(pid_t uid)

--- a/src/kmod/cb-banning.c
+++ b/src/kmod/cb-banning.c
@@ -325,8 +325,7 @@ void cbClearIgnoredProcess(pid_t pid)
 
 	if (max) {
 		atomic64_set((atomic64_t *)&g_cb_ignored_pid_count, 0);
-		memset(g_cb_ignored_pids, 0,
-		       sizeof(g_cb_ignored_pids));
+		memset(g_cb_ignored_pids, 0, sizeof(g_cb_ignored_pids));
 	}
 }
 

--- a/src/kmod/cb-banning.h
+++ b/src/kmod/cb-banning.h
@@ -13,7 +13,7 @@ extern inline bool cbClearBannedProcessInode(uint64_t ino);
 extern bool	   cbKillBannedProcessByInode(uint64_t ino);
 extern bool	   cbIngoreProcess(pid_t pid);
 extern void	   cbSetIgnoredProcess(pid_t pid);
-extern void        cbClearIgnoredProcess(pid_t pid);
+extern void	   cbClearIgnoredProcess(pid_t pid);
 extern bool	   cbIngoreUid(pid_t uid);
 extern void	   cbSetIgnoredUid(uid_t uid);
 extern void	   cbClearAllBans(void);

--- a/src/kmod/cb-banning.h
+++ b/src/kmod/cb-banning.h
@@ -13,6 +13,7 @@ extern inline bool cbClearBannedProcessInode(uint64_t ino);
 extern bool	   cbKillBannedProcessByInode(uint64_t ino);
 extern bool	   cbIngoreProcess(pid_t pid);
 extern void	   cbSetIgnoredProcess(pid_t pid);
+extern void        cbClearIgnoredProcess(pid_t pid);
 extern bool	   cbIngoreUid(pid_t uid);
 extern void	   cbSetIgnoredUid(uid_t uid);
 extern void	   cbClearAllBans(void);

--- a/src/kmod/priv.h
+++ b/src/kmod/priv.h
@@ -58,6 +58,7 @@ extern atomic64_t module_used;
 // Exclusion functions
 //
 extern void cbSetIgnoredProcess(pid_t pid);
+extern void cbClearIgnoredProcess(pid_t pid);
 extern bool cbIngoreProcess(pid_t pid);
 extern void cbSetIgnoredUid(uid_t uid);
 extern bool cbIngoreUid(pid_t uid);

--- a/src/kmod/process-hooks.c
+++ b/src/kmod/process-hooks.c
@@ -176,7 +176,7 @@ void cb_task_free(struct task_struct *p)
 	}
 
 	if (cbIngoreProcess(p->pid)) {
-                cbClearIgnoredProcess(p->pid);
+		cbClearIgnoredProcess(p->pid);
 	}
 
 	ret = process_tracking_remove_process(p->pid);
@@ -210,7 +210,7 @@ int task_wait(struct task_struct *p)
 	MODULE_GET();
 
 	if (cbIngoreProcess(pid)) {
-	        cbClearIgnoredProcess(pid);
+		cbClearIgnoredProcess(pid);
 	}
 
 	// If not the main thread then we shouldn't care too

--- a/src/kmod/process-hooks.c
+++ b/src/kmod/process-hooks.c
@@ -176,7 +176,7 @@ void cb_task_free(struct task_struct *p)
 	}
 
 	if (cbIngoreProcess(p->pid)) {
-		goto task_free_exit;
+                cbClearIgnoredProcess(p->pid);
 	}
 
 	ret = process_tracking_remove_process(p->pid);
@@ -210,7 +210,7 @@ int task_wait(struct task_struct *p)
 	MODULE_GET();
 
 	if (cbIngoreProcess(pid)) {
-		goto task_wait_exit;
+	        cbClearIgnoredProcess(pid);
 	}
 
 	// If not the main thread then we shouldn't care too


### PR DESCRIPTION
The trusted pid was not correctly cleaned up when a trusted process exits, which caused the process tracking table maintaining some obsoleted pid items.  The trusted pid list is also cleaned up when the trusted process exits.  