### PR TITLE
Enable kernel module debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build: container
 		&& sed '/build_requires/a $(KERNEL_PACKAGE)' ../conanfile.txt > conanfile.txt \
 		&& conan install . -j kernel-headers.json \
 		&& cmake -DKERNELDIR=`jq -r .installed[0].packages[0].cpp_info.rootpath < kernel-headers.json`/kernel .. \
-		&& make \
+		&& make VERBOSE=1 \
 		"
 
 clean:

--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -32,8 +32,9 @@ set(SYMBOLS_INSTALL_COMMAND objcopy --only-keep-debug ${DRIVER_FILE} ${DRIVER_FI
 FILE(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/Kbuild "obj-m := cbsensor.o
 ccflags-y := -Wall -Wformat
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
-    ccflags-y += -g
+ccflags-y += -g
 endif()
+
 cbsensor-objs := drvmain.o \
                  file-helper.o \
                  file-hooks.o \

--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -24,13 +24,14 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 set(DRIVER_FILE cbsensor.ko)
 
-set(KBUILD_CMD $(MAKE) --no-print-directory -C ${KERNELDIR} M=${CMAKE_CURRENT_BINARY_DIR} src=${CMAKE_CURRENT_SOURCE_DIR} o=${CMAKE_CURRENT_BINARY_DIR} V=0)
+set(KBUILD_CMD $(MAKE) --no-print-directory -C ${KERNELDIR} M=${CMAKE_CURRENT_BINARY_DIR} src=${CMAKE_CURRENT_SOURCE_DIR} o=${CMAKE_CURRENT_BINARY_DIR} V=2)
 
 set(SYMBOLS_INSTALL_COMMAND objcopy --only-keep-debug ${DRIVER_FILE} ${DRIVER_FILE}.debug && ${CMAKE_STRIP} --strip-unneeded ${DRIVER_FILE})
 
-FLAGS:= -Wall -Wformat
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
-    FLAGS += -g
+    set(KMOD_FLAGS -g -Wall -Wformat)
+else()
+    set(KMOD_FLAGS -Wall -Wformat)
 endif()
 
 # Generate the Kbuild file through cmake.

--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -30,7 +30,10 @@ set(SYMBOLS_INSTALL_COMMAND objcopy --only-keep-debug ${DRIVER_FILE} ${DRIVER_FI
 
 # Generate the Kbuild file through cmake.
 FILE(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/Kbuild "obj-m := cbsensor.o
-ccflags-y :=  -g -DDEBUG -Wall -Wformat
+ccflags-y := -Wall -Wformat
+if (CMAKE_BUILD_TYPE STREQUAL Debug)
+    ccflags-y += -g
+endif()
 cbsensor-objs := drvmain.o \
                  file-helper.o \
                  file-hooks.o \

--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SYMBOLS_INSTALL_COMMAND objcopy --only-keep-debug ${DRIVER_FILE} ${DRIVER_FI
 
 # Generate the Kbuild file through cmake.
 FILE(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/Kbuild "obj-m := cbsensor.o
-ccflags-y :=  -Wall -Wformat
+ccflags-y :=  -g -DDEBUG -Wall -Wformat
 cbsensor-objs := drvmain.o \
                  file-helper.o \
                  file-hooks.o \

--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(cbsensor VERSION 1.0.1.1${cbsensor_VERSION_TWEAK} LANGUAGES C)
+project(cbsensor VERSION 1.0.3 LANGUAGES C)
 
 if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
     include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/src/kmod/CMakeLists.txt
+++ b/src/kmod/CMakeLists.txt
@@ -28,12 +28,14 @@ set(KBUILD_CMD $(MAKE) --no-print-directory -C ${KERNELDIR} M=${CMAKE_CURRENT_BI
 
 set(SYMBOLS_INSTALL_COMMAND objcopy --only-keep-debug ${DRIVER_FILE} ${DRIVER_FILE}.debug && ${CMAKE_STRIP} --strip-unneeded ${DRIVER_FILE})
 
+FLAGS:= -Wall -Wformat
+if (CMAKE_BUILD_TYPE STREQUAL Debug)
+    FLAGS += -g
+endif()
+
 # Generate the Kbuild file through cmake.
 FILE(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/Kbuild "obj-m := cbsensor.o
-ccflags-y := -Wall -Wformat
-if (CMAKE_BUILD_TYPE STREQUAL Debug)
-ccflags-y += -g
-endif()
+ccflags-y := ${FLAGS}
 
 cbsensor-objs := drvmain.o \
                  file-helper.o \


### PR DESCRIPTION
Build module with debug enabled.  We will strip the debug symbols out when packaging for release.

Signed-off-by: Daniel Heater <daniel@heatertech.com>